### PR TITLE
LFLT-536 Clean and shape up Leaflet Backend service

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>hu.psprog.leaflet</groupId>
     <artifactId>leaflet-stack-base-bom</artifactId>
-    <version>2.1-r2302.1</version>
+    <version>2.2-r2302.2</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -30,10 +30,10 @@
         <maven.build.timestamp.format>yyyy-MM-dd HH:mm z</maven.build.timestamp.format>
 
         <!-- Leaflet component versions -->
-        <leaflet.api.version>1.6.11</leaflet.api.version>
+        <leaflet.api.version>2.0.0</leaflet.api.version>
         <leaflet.bridge.version>3.4.1</leaflet.bridge.version>
         <leaflet.oauth-support.version>1.0.1</leaflet.oauth-support.version>
-        <leaflet.rcp.version>1.10.1</leaflet.rcp.version>
+        <leaflet.rcp.version>1.11.0</leaflet.rcp.version>
         <leaflet.tlp-appender.version>1.1.5</leaflet.tlp-appender.version>
         <leaflet.tlql.version>1.0.3</leaflet.tlql.version>
         <leaflet.translation-adapter.version>2.1.5</leaflet.translation-adapter.version>
@@ -108,31 +108,6 @@
                 <groupId>hu.psprog.leaflet</groupId>
                 <artifactId>oauth-frontend-support</artifactId>
                 <version>${leaflet.oauth-support.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>hu.psprog.leaflet</groupId>
-                <artifactId>leaflet-jwt-component</artifactId>
-                <version>${leaflet.jwt.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>hu.psprog.leaflet</groupId>
-                <artifactId>jwt-auth-support-api</artifactId>
-                <version>${leaflet.jwt-auth-support.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>hu.psprog.leaflet</groupId>
-                <artifactId>jwt-auth-handler</artifactId>
-                <version>${leaflet.jwt-auth-support.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>hu.psprog.leaflet</groupId>
-                <artifactId>jwt-auth-front-end-support</artifactId>
-                <version>${leaflet.jwt-auth-support.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>hu.psprog.leaflet</groupId>
-                <artifactId>leaflet-mailer-component</artifactId>
-                <version>${leaflet.mail.version}</version>
             </dependency>
             <dependency>
                 <groupId>hu.psprog.leaflet</groupId>


### PR DESCRIPTION
 - Bumped REST API version to 2.0.0
 - Bumped RCP version to 1.11.0
 - Removed deprecated support components
 - Bumped library version to 2.2-r2302.2