### PR TITLE
LFLT-610 Migrate all support library to Java 21

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,15 +1,19 @@
 version: 2.1
+
 orbs:
-  jira: circleci/jira@1.3.1
+  jira: circleci/jira@2.1.0
+  jq: circleci/jq@3.0.0
+
 jobs:
   build:
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/eclipse-temurin:21-jdk
     steps:
       - checkout
       - run:
           command: mvn clean deploy -s .circleci/settings.xml
           name: Build and upload to Leaflet Internal repository
+
 workflows:
   build:
     jobs:
@@ -21,6 +25,7 @@ workflows:
                - master
          post-steps:
            - jira/notify:
-               environment_type: production
-               job_type: build
-  version: 2.1
+               pipeline_id: << pipeline.id >>
+               pipeline_number: << pipeline.number >>
+
+  version: 2

--- a/pom.xml
+++ b/pom.xml
@@ -6,19 +6,19 @@
 
     <groupId>hu.psprog.leaflet</groupId>
     <artifactId>leaflet-stack-base-bom</artifactId>
-    <version>3.2-r2307.3</version>
+    <version>4.0-r2405.1</version>
     <packaging>pom</packaging>
 
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.1.0</version>
+        <version>3.3.0</version>
     </parent>
 
     <properties>
 
         <!-- Java environment version -->
-        <java.version>17</java.version>
+        <java.version>21</java.version>
 
         <!-- compiler settings -->
         <maven.compiler.source>${java.version}</maven.compiler.source>
@@ -30,32 +30,30 @@
         <maven.build.timestamp.format>yyyy-MM-dd HH:mm z</maven.build.timestamp.format>
 
         <!-- Leaflet component versions -->
-        <leaflet.api.version>2.3.0</leaflet.api.version>
-        <leaflet.bridge.version>3.5.0</leaflet.bridge.version>
-        <leaflet.oauth-support.version>1.1.0</leaflet.oauth-support.version>
-        <leaflet.rcp.version>1.14.1</leaflet.rcp.version>
-        <leaflet.tlp-appender.version>1.2.0</leaflet.tlp-appender.version>
-        <leaflet.tlql.version>1.2.0</leaflet.tlql.version>
-        <leaflet.translation-adapter.version>2.2.0</leaflet.translation-adapter.version>
+        <leaflet.api.version>2.4.0</leaflet.api.version>
+        <leaflet.bridge.version>3.6.0</leaflet.bridge.version>
+        <leaflet.oauth-support.version>1.2.0</leaflet.oauth-support.version>
+        <leaflet.rcp.version>1.15.0</leaflet.rcp.version>
+        <leaflet.tlql.version>1.3.0</leaflet.tlql.version>
+        <leaflet.translation-adapter.version>2.3.0</leaflet.translation-adapter.version>
 
         <!-- other versions -->
-        <commonmark.version>0.21.0</commonmark.version>
+        <commonmark.version>0.22.0</commonmark.version>
         <commons-collections4.version>4.4</commons-collections4.version>
-        <commons-io.version>2.11.0</commons-io.version>
-        <commons-lang.version>3.12.0</commons-lang.version>
+        <commons-io.version>2.16.1</commons-io.version>
+        <commons-lang.version>3.14.0</commons-lang.version>
         <commons-math3.version>3.6.1</commons-math3.version>
-        <spark-java.version>2.9.4</spark-java.version>
-        <logstash-logback-encoder.version>7.3</logstash-logback-encoder.version>
+        <logstash-logback-encoder.version>7.4</logstash-logback-encoder.version>
 
         <!-- Maven plugin versions -->
         <apt-maven-plugin.version>1.1.3</apt-maven-plugin.version>
         <dockerfile-maven-plugin.version>1.4.13</dockerfile-maven-plugin.version>
-        <jacoco-maven-plugin.version>0.8.10</jacoco-maven-plugin.version>
-        <maven-failsafe-plugin.version>3.0.0</maven-failsafe-plugin.version>
-        <maven-surefire-plugin.version>3.0.0</maven-surefire-plugin.version>
+        <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
+        <maven-failsafe-plugin.version>3.2.5</maven-failsafe-plugin.version>
+        <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
 
         <!-- test framework versions -->
-        <wiremock.version>2.35.0</wiremock.version>
+        <wiremock.version>3.5.4</wiremock.version>
 
     </properties>
 
@@ -97,11 +95,6 @@
                 <groupId>hu.psprog.leaflet</groupId>
                 <artifactId>leaflet-tlql-processor</artifactId>
                 <version>${leaflet.tlql.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>hu.psprog.leaflet</groupId>
-                <artifactId>tlp-appender</artifactId>
-                <version>${leaflet.tlp-appender.version}</version>
             </dependency>
             <dependency>
                 <groupId>hu.psprog.leaflet</groupId>
@@ -155,11 +148,6 @@
             </dependency>
             <dependency>
                 <groupId>hu.psprog.leaflet</groupId>
-                <artifactId>rcp-hystrix-support</artifactId>
-                <version>${leaflet.rcp.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>hu.psprog.leaflet</groupId>
                 <artifactId>rcp-request-adapters</artifactId>
                 <version>${leaflet.rcp.version}</version>
             </dependency>
@@ -206,17 +194,6 @@
                 <version>${commonmark.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.sparkjava</groupId>
-                <artifactId>spark-core</artifactId>
-                <version>${spark-java.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>javax.servlet</groupId>
-                        <artifactId>javax.servlet-api</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-math3</artifactId>
                 <version>${commons-math3.version}</version>
@@ -229,8 +206,8 @@
 
             <!-- test dependencies -->
             <dependency>
-                <groupId>com.github.tomakehurst</groupId>
-                <artifactId>wiremock-jre8-standalone</artifactId>
+                <groupId>org.wiremock</groupId>
+                <artifactId>wiremock-standalone</artifactId>
                 <version>${wiremock.version}</version>
                 <scope>test</scope>
             </dependency>


### PR DESCRIPTION
 - Updated Java version to 21
 - Updated Spring Boot Starter version to 3.3.0
 - Updated dependencies
 - Updated Leaflet Stack library versions
 - Updated CircleCI build pipeline config
 - Bumped library version to 4.0-r2405.1