### PR TITLE
LFLT-655 Migrate Java applications to Spring Boot v4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,13 +6,13 @@
 
     <groupId>hu.psprog.leaflet</groupId>
     <artifactId>leaflet-stack-base-bom</artifactId>
-    <version>5.0-r2505.1</version>
+    <version>6.0-r2604.1</version>
     <packaging>pom</packaging>
 
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.4.5</version>
+        <version>4.0.6</version>
     </parent>
 
     <properties>
@@ -30,29 +30,26 @@
         <maven.build.timestamp.format>yyyy-MM-dd HH:mm z</maven.build.timestamp.format>
 
         <!-- Leaflet component versions -->
-        <leaflet.api.version>2.4.1</leaflet.api.version>
-        <leaflet.bridge.version>3.6.1</leaflet.bridge.version>
-        <leaflet.oauth-support.version>1.2.1</leaflet.oauth-support.version>
-        <leaflet.rcp.version>1.15.1</leaflet.rcp.version>
-        <leaflet.tlql.version>1.3.1</leaflet.tlql.version>
-        <leaflet.translation-adapter.version>2.3.1</leaflet.translation-adapter.version>
+        <leaflet.api.version>2.5.0</leaflet.api.version>
+        <leaflet.bridge.version>4.0.0</leaflet.bridge.version>
+        <leaflet.oauth-support.version>1.3.0</leaflet.oauth-support.version>
+        <leaflet.rcp.version>2.0.0</leaflet.rcp.version>
+        <leaflet.tlql.version>1.4.0</leaflet.tlql.version>
+        <leaflet.translation-adapter.version>2.4.0</leaflet.translation-adapter.version>
 
         <!-- other versions -->
-        <commonmark.version>0.24.0</commonmark.version>
-        <commons-collections4.version>4.5.0</commons-collections4.version>
-        <commons-io.version>2.19.0</commons-io.version>
-        <commons-lang.version>3.17.0</commons-lang.version>
-        <commons-math3.version>3.6.1</commons-math3.version>
-        <logstash-logback-encoder.version>8.1</logstash-logback-encoder.version>
+        <commonmark.version>0.28.0</commonmark.version>
+        <commons-lang.version>3.20.0</commons-lang.version>
+        <logstash-logback-encoder.version>9.0</logstash-logback-encoder.version>
 
         <!-- Maven plugin versions -->
         <dockerfile-maven-plugin.version>1.4.13</dockerfile-maven-plugin.version>
-        <jacoco-maven-plugin.version>0.8.13</jacoco-maven-plugin.version>
-        <maven-failsafe-plugin.version>3.5.3</maven-failsafe-plugin.version>
-        <maven-surefire-plugin.version>3.5.3</maven-surefire-plugin.version>
+        <jacoco-maven-plugin.version>0.8.14</jacoco-maven-plugin.version>
+        <maven-failsafe-plugin.version>3.5.5</maven-failsafe-plugin.version>
+        <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>
 
         <!-- test framework versions -->
-        <wiremock.version>3.13.0</wiremock.version>
+        <wiremock.version>3.13.2</wiremock.version>
 
     </properties>
 
@@ -127,16 +124,6 @@
             </dependency>
             <dependency>
                 <groupId>hu.psprog.leaflet</groupId>
-                <artifactId>failover-rest-client</artifactId>
-                <version>${leaflet.rcp.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>hu.psprog.leaflet</groupId>
-                <artifactId>failover-rest-api</artifactId>
-                <version>${leaflet.rcp.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>hu.psprog.leaflet</groupId>
                 <artifactId>recaptcha-rest-client</artifactId>
                 <version>${leaflet.rcp.version}</version>
             </dependency>
@@ -160,16 +147,6 @@
                 <artifactId>lens-rest-client</artifactId>
                 <version>${leaflet.rcp.version}</version>
             </dependency>
-            <dependency>
-                <groupId>hu.psprog.leaflet</groupId>
-                <artifactId>lsrs-rest-api</artifactId>
-                <version>${leaflet.rcp.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>hu.psprog.leaflet</groupId>
-                <artifactId>lsrs-rest-client</artifactId>
-                <version>${leaflet.rcp.version}</version>
-            </dependency>
 
             <!-- other dependencies -->
             <dependency>
@@ -178,24 +155,9 @@
                 <version>${commons-lang.version}</version>
             </dependency>
             <dependency>
-                <groupId>commons-io</groupId>
-                <artifactId>commons-io</artifactId>
-                <version>${commons-io.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-collections4</artifactId>
-                <version>${commons-collections4.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.commonmark</groupId>
                 <artifactId>commonmark</artifactId>
                 <version>${commonmark.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-math3</artifactId>
-                <version>${commons-math3.version}</version>
             </dependency>
             <dependency>
                 <groupId>net.logstash.logback</groupId>


### PR DESCRIPTION
 - Updated Spring Boot Starter Parent version to 4.0.6
 - Updated additional dependencies
 - Dropped some unnecessary dependencies
 - Bumped library version to 6.0-r2504.1