### PR TITLE
LFLT-655 Migrate Java applications to Spring Boot v4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>hu.psprog.leaflet</groupId>
     <artifactId>leaflet-stack-base-bom</artifactId>
-    <version>6.0-r2604.1</version>
+    <version>6.0-r2604.2</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -31,7 +31,7 @@
 
         <!-- Leaflet component versions -->
         <leaflet.api.version>2.5.0</leaflet.api.version>
-        <leaflet.bridge.version>4.0.0</leaflet.bridge.version>
+        <leaflet.bridge.version>4.0.1</leaflet.bridge.version>
         <leaflet.oauth-support.version>1.3.0</leaflet.oauth-support.version>
         <leaflet.rcp.version>2.0.0</leaflet.rcp.version>
         <leaflet.tlql.version>1.4.0</leaflet.tlql.version>


### PR DESCRIPTION
 - Bumped Bridge library version to 4.0.1
 - Bumped library version to 6.0-r2504.2